### PR TITLE
If found iddle client in the pool is invalid pointing to the mongo node…

### DIFF
--- a/src/Mapless-Mongo-Core/MaplessMongoReplicaSetPool.class.st
+++ b/src/Mapless-Mongo-Core/MaplessMongoReplicaSetPool.class.st
@@ -573,6 +573,10 @@ MaplessMongoReplicaSetPool >> onNotPrimaryReadWriteAttempt: aBlock using: aMongo
 	self ensureMinimumQuantityOfReadWriteClients
 ]
 
+{ #category : #actions }
+MaplessMongoReplicaSetPool >> onPrimaryFound [
+]
+
 { #category : #reactions }
 MaplessMongoReplicaSetPool >> onPrimaryFound: aMongoAPI [
 	self removeInvalidClients.
@@ -821,7 +825,7 @@ MaplessMongoReplicaSetPool >> requestReadOnlyClient [
 				ifFalse: [ self hasMaxReadOnlyClients
 						ifTrue: [ ^ MaplessMaximumReadWritePoolClientsReached signal ].
 					self makeReadOnlyClient ].
-			(client notNil and: [ client isValid not ])
+			(client notNil and: [ ([ client isValid not ] on: Error do: [ :ex| true ]) ])
 				ifTrue: [ self removeReadOnlyClient: client ifAbsent: [ nil ].
 					client := self makeReadOnlyClient ].
 			self removeReadOnlyClient: client ifAbsent: [ nil ].


### PR DESCRIPTION
…which went down (see requestReadOnlyClient), make sure to remove ii from the pool in case if #isValid protocol raises an error.

Added NOP onPrimaryFound to let unit tests complete. onPrimaryFound is to be reimplemented by the app which uses mapless.